### PR TITLE
upd: 設定ファイルに icon_on_form を追加。起動時にラベルを上書き

### DIFF
--- a/mpost/App.config
+++ b/mpost/App.config
@@ -8,5 +8,6 @@
     <add key="raspi_twitter_token_json_path" value="" />
     <add key="slack_access_token" value="" />
     <add key="slack_channel_name" value="" />
+    <add key="icon_on_form" value="🐢" />
   </appSettings>
 </configuration>

--- a/mpost/mpost.Designer.cs
+++ b/mpost/mpost.Designer.cs
@@ -28,120 +28,20 @@
         /// </summary>
         private void InitializeComponent()
         {
-            spcMain = new SplitContainer();
-            txtMessage = new TextBox();
-            lblPet = new Label();
-            lblMaxWC = new Label();
-            lblCurrentWC = new Label();
-            chkTwitter = new CheckBox();
-            chkSlack = new CheckBox();
             btnPost = new Button();
-            ((System.ComponentModel.ISupportInitialize)spcMain).BeginInit();
-            spcMain.Panel1.SuspendLayout();
-            spcMain.Panel2.SuspendLayout();
-            spcMain.SuspendLayout();
+            chkSlack = new CheckBox();
+            chkTwitter = new CheckBox();
+            lblCurrentWC = new Label();
+            lblMaxWC = new Label();
+            lblPet = new Label();
+            txtMessage = new TextBox();
             SuspendLayout();
-            // 
-            // spcMain
-            // 
-            spcMain.Dock = DockStyle.Fill;
-            spcMain.FixedPanel = FixedPanel.Panel2;
-            spcMain.Location = new Point(0, 0);
-            spcMain.Name = "spcMain";
-            spcMain.Orientation = Orientation.Horizontal;
-            // 
-            // spcMain.Panel1
-            // 
-            spcMain.Panel1.Controls.Add(txtMessage);
-            // 
-            // spcMain.Panel2
-            // 
-            spcMain.Panel2.Controls.Add(lblPet);
-            spcMain.Panel2.Controls.Add(lblMaxWC);
-            spcMain.Panel2.Controls.Add(lblCurrentWC);
-            spcMain.Panel2.Controls.Add(chkTwitter);
-            spcMain.Panel2.Controls.Add(chkSlack);
-            spcMain.Panel2.Controls.Add(btnPost);
-            spcMain.Size = new Size(584, 243);
-            spcMain.SplitterDistance = 187;
-            spcMain.TabIndex = 0;
-            // 
-            // txtMessage
-            // 
-            txtMessage.Dock = DockStyle.Fill;
-            txtMessage.Font = new Font("Yu Gothic UI", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 128);
-            txtMessage.Location = new Point(0, 0);
-            txtMessage.Multiline = true;
-            txtMessage.Name = "txtMessage";
-            txtMessage.PlaceholderText = "ここに投稿する内容を書きます";
-            txtMessage.Size = new Size(584, 187);
-            txtMessage.TabIndex = 0;
-            txtMessage.TextChanged += txtMessage_TextChanged;
-            // 
-            // lblPet
-            // 
-            lblPet.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            lblPet.AutoSize = true;
-            lblPet.BackColor = Color.Transparent;
-            lblPet.Font = new Font("Yu Gothic UI", 20.25F, FontStyle.Regular, GraphicsUnit.Point, 128);
-            lblPet.Location = new Point(3, 3);
-            lblPet.Name = "lblPet";
-            lblPet.Size = new Size(54, 37);
-            lblPet.TabIndex = 2;
-            lblPet.Text = "🐢";
-            // 
-            // lblMaxWC
-            // 
-            lblMaxWC.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            lblMaxWC.AutoSize = true;
-            lblMaxWC.Font = new Font("Yu Gothic UI", 12F, FontStyle.Regular, GraphicsUnit.Point, 128);
-            lblMaxWC.Location = new Point(442, 16);
-            lblMaxWC.Name = "lblMaxWC";
-            lblMaxWC.Size = new Size(47, 21);
-            lblMaxWC.TabIndex = 2;
-            lblMaxWC.Text = "/ 140";
-            // 
-            // lblCurrentWC
-            // 
-            lblCurrentWC.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            lblCurrentWC.Font = new Font("Yu Gothic UI", 12F, FontStyle.Regular, GraphicsUnit.Point, 128);
-            lblCurrentWC.Location = new Point(404, 15);
-            lblCurrentWC.Name = "lblCurrentWC";
-            lblCurrentWC.Size = new Size(41, 23);
-            lblCurrentWC.TabIndex = 2;
-            lblCurrentWC.Text = "0";
-            lblCurrentWC.TextAlign = ContentAlignment.MiddleRight;
-            // 
-            // chkTwitter
-            // 
-            chkTwitter.AutoSize = true;
-            chkTwitter.Checked = true;
-            chkTwitter.CheckState = CheckState.Checked;
-            chkTwitter.Font = new Font("Yu Gothic UI", 12F);
-            chkTwitter.Location = new Point(60, 15);
-            chkTwitter.Name = "chkTwitter";
-            chkTwitter.Size = new Size(76, 25);
-            chkTwitter.TabIndex = 1;
-            chkTwitter.Text = "Twitter";
-            chkTwitter.UseVisualStyleBackColor = true;
-            // 
-            // chkSlack
-            // 
-            chkSlack.AutoSize = true;
-            chkSlack.Checked = true;
-            chkSlack.CheckState = CheckState.Checked;
-            chkSlack.Font = new Font("Yu Gothic UI", 12F);
-            chkSlack.Location = new Point(142, 15);
-            chkSlack.Name = "chkSlack";
-            chkSlack.Size = new Size(65, 25);
-            chkSlack.TabIndex = 1;
-            chkSlack.Text = "Slack";
-            chkSlack.UseVisualStyleBackColor = true;
             // 
             // btnPost
             // 
+            btnPost.Enabled = false;
             btnPost.Font = new Font("Yu Gothic UI", 12F, FontStyle.Regular, GraphicsUnit.Point, 128);
-            btnPost.Location = new Point(498, 9);
+            btnPost.Location = new Point(501, 119);
             btnPost.Name = "btnPost";
             btnPost.Size = new Size(75, 34);
             btnPost.TabIndex = 0;
@@ -149,13 +49,95 @@
             btnPost.UseVisualStyleBackColor = true;
             btnPost.Click += btnPost_Click;
             // 
+            // chkSlack
+            // 
+            chkSlack.AutoSize = true;
+            chkSlack.Checked = true;
+            chkSlack.CheckState = CheckState.Checked;
+            chkSlack.Font = new Font("Yu Gothic UI", 12F);
+            chkSlack.Location = new Point(144, 123);
+            chkSlack.Name = "chkSlack";
+            chkSlack.Size = new Size(65, 25);
+            chkSlack.TabIndex = 1;
+            chkSlack.Text = "Slack";
+            chkSlack.UseVisualStyleBackColor = true;
+            // 
+            // chkTwitter
+            // 
+            chkTwitter.AutoSize = true;
+            chkTwitter.Checked = true;
+            chkTwitter.CheckState = CheckState.Checked;
+            chkTwitter.Font = new Font("Yu Gothic UI", 12F);
+            chkTwitter.Location = new Point(63, 123);
+            chkTwitter.Name = "chkTwitter";
+            chkTwitter.Size = new Size(76, 25);
+            chkTwitter.TabIndex = 1;
+            chkTwitter.Text = "Twitter";
+            chkTwitter.UseVisualStyleBackColor = true;
+            // 
+            // lblCurrentWC
+            // 
+            lblCurrentWC.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            lblCurrentWC.Font = new Font("Yu Gothic UI", 12F, FontStyle.Regular, GraphicsUnit.Point, 128);
+            lblCurrentWC.Location = new Point(410, 123);
+            lblCurrentWC.Name = "lblCurrentWC";
+            lblCurrentWC.Size = new Size(41, 23);
+            lblCurrentWC.TabIndex = 2;
+            lblCurrentWC.Text = "0";
+            lblCurrentWC.TextAlign = ContentAlignment.MiddleRight;
+            // 
+            // lblMaxWC
+            // 
+            lblMaxWC.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            lblMaxWC.AutoSize = true;
+            lblMaxWC.Font = new Font("Yu Gothic UI", 12F, FontStyle.Regular, GraphicsUnit.Point, 128);
+            lblMaxWC.Location = new Point(448, 124);
+            lblMaxWC.Name = "lblMaxWC";
+            lblMaxWC.Size = new Size(47, 21);
+            lblMaxWC.TabIndex = 2;
+            lblMaxWC.Text = "/ 140";
+            // 
+            // lblPet
+            // 
+            lblPet.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            lblPet.AutoSize = true;
+            lblPet.BackColor = Color.Transparent;
+            lblPet.Font = new Font("Yu Gothic UI", 20.25F, FontStyle.Regular, GraphicsUnit.Point, 128);
+            lblPet.Location = new Point(4, 112);
+            lblPet.Name = "lblPet";
+            lblPet.Size = new Size(54, 37);
+            lblPet.TabIndex = 2;
+            lblPet.Text = "🐢";
+            // 
+            // txtMessage
+            // 
+            txtMessage.BackColor = Color.White;
+            txtMessage.Font = new Font("Yu Gothic UI", 14.25F, FontStyle.Regular, GraphicsUnit.Point, 128);
+            txtMessage.ForeColor = Color.Black;
+            txtMessage.ImeMode = ImeMode.On;
+            txtMessage.Location = new Point(2, 2);
+            txtMessage.Multiline = true;
+            txtMessage.Name = "txtMessage";
+            txtMessage.PlaceholderText = "ここに投稿する内容を書きます";
+            txtMessage.Size = new Size(580, 111);
+            txtMessage.TabIndex = 0;
+            txtMessage.TextChanged += txtMessage_TextChanged;
+            // 
             // frmMPost
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            ClientSize = new Size(584, 243);
-            Controls.Add(spcMain);
+            BackColor = SystemColors.Control;
+            ClientSize = new Size(584, 157);
+            Controls.Add(txtMessage);
+            Controls.Add(lblPet);
+            Controls.Add(lblMaxWC);
+            Controls.Add(btnPost);
+            Controls.Add(lblCurrentWC);
+            Controls.Add(chkSlack);
+            Controls.Add(chkTwitter);
+            FormBorderStyle = FormBorderStyle.Fixed3D;
             MaximizeBox = false;
             MinimizeBox = false;
             Name = "frmMPost";
@@ -163,24 +145,18 @@
             SizeGripStyle = SizeGripStyle.Hide;
             Text = "mpost";
             TopMost = true;
-            spcMain.Panel1.ResumeLayout(false);
-            spcMain.Panel1.PerformLayout();
-            spcMain.Panel2.ResumeLayout(false);
-            spcMain.Panel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)spcMain).EndInit();
-            spcMain.ResumeLayout(false);
             ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
 
-        private SplitContainer spcMain;
-        private TextBox txtMessage;
-        private CheckBox chkTwitter;
-        private CheckBox chkSlack;
         private Button btnPost;
-        private Label lblMaxWC;
+        private CheckBox chkSlack;
+        private CheckBox chkTwitter;
         private Label lblCurrentWC;
+        private Label lblMaxWC;
         private Label lblPet;
+        private TextBox txtMessage;
     }
 }

--- a/mpost/mpost.cs
+++ b/mpost/mpost.cs
@@ -28,6 +28,7 @@ namespace mpost
         public frmMPost()
         {
             InitializeComponent();
+            lblPet.Text = ConfigurationManager.AppSettings["icon_on_form"] ?? "";  // ペットマークを差替
 
             string tt = File.ReadAllText(@"twitter-text-3.1.0.js");
             v8 = new V8ScriptEngine();


### PR DESCRIPTION
設定ファイルに icon_on_form を追加。
起動時にラベルを上書きする。

設定ファイルにキーそのものがない場合は、空文字となる。
文字列長の制限は行わなかった。

※ はじめは頭一文字で実装していたが、
🐢が適切に表示されなかったので、やめた。

設定ファイルにてユーザー責任で変更できるため、
一文字制限は行わないことにする。