### PR TITLE
upd: 一つ前の投稿を表示する機能と、クリア機能を追加

### DIFF
--- a/mpost/App.config
+++ b/mpost/App.config
@@ -9,5 +9,6 @@
     <add key="slack_access_token" value="" />
     <add key="slack_channel_name" value="" />
     <add key="icon_on_form" value="🐢" />
+    <add key="previous_post_file_name" value="previousPost.txt" />
   </appSettings>
 </configuration>

--- a/mpost/mpost.Designer.cs
+++ b/mpost/mpost.Designer.cs
@@ -28,13 +28,18 @@
         /// </summary>
         private void InitializeComponent()
         {
+            components = new System.ComponentModel.Container();
             btnPost = new Button();
             chkSlack = new CheckBox();
             chkTwitter = new CheckBox();
             lblCurrentWC = new Label();
             lblMaxWC = new Label();
             lblPet = new Label();
+            cmsPet = new ContextMenuStrip(components);
+            tsmItemPreviousPost = new ToolStripMenuItem();
             txtMessage = new TextBox();
+            tsmItemClear = new ToolStripMenuItem();
+            cmsPet.SuspendLayout();
             SuspendLayout();
             // 
             // btnPost
@@ -102,12 +107,26 @@
             lblPet.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
             lblPet.AutoSize = true;
             lblPet.BackColor = Color.Transparent;
+            lblPet.ContextMenuStrip = cmsPet;
             lblPet.Font = new Font("Yu Gothic UI", 20.25F, FontStyle.Regular, GraphicsUnit.Point, 128);
             lblPet.Location = new Point(4, 112);
             lblPet.Name = "lblPet";
             lblPet.Size = new Size(54, 37);
             lblPet.TabIndex = 2;
             lblPet.Text = "🐢";
+            // 
+            // cmsPet
+            // 
+            cmsPet.Items.AddRange(new ToolStripItem[] { tsmItemPreviousPost, tsmItemClear });
+            cmsPet.Name = "cmsPet";
+            cmsPet.Size = new Size(175, 48);
+            // 
+            // tsmItemPreviousPost
+            // 
+            tsmItemPreviousPost.Name = "tsmItemPreviousPost";
+            tsmItemPreviousPost.Size = new Size(174, 22);
+            tsmItemPreviousPost.Text = "一つ前の投稿を表示";
+            tsmItemPreviousPost.Click += tsmItemPreviousPost_Click;
             // 
             // txtMessage
             // 
@@ -122,6 +141,13 @@
             txtMessage.Size = new Size(580, 111);
             txtMessage.TabIndex = 0;
             txtMessage.TextChanged += txtMessage_TextChanged;
+            // 
+            // tsmItemClear
+            // 
+            tsmItemClear.Name = "tsmItemClear";
+            tsmItemClear.Size = new Size(174, 22);
+            tsmItemClear.Text = "クリア";
+            tsmItemClear.Click += tsmItemClear_Click;
             // 
             // frmMPost
             // 
@@ -145,6 +171,7 @@
             SizeGripStyle = SizeGripStyle.Hide;
             Text = "mpost";
             TopMost = true;
+            cmsPet.ResumeLayout(false);
             ResumeLayout(false);
             PerformLayout();
         }
@@ -158,5 +185,8 @@
         private Label lblMaxWC;
         private Label lblPet;
         private TextBox txtMessage;
+        private ContextMenuStrip cmsPet;
+        private ToolStripMenuItem tsmItemPreviousPost;
+        private ToolStripMenuItem tsmItemClear;
     }
 }

--- a/mpost/mpost.cs
+++ b/mpost/mpost.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Renci.SshNet;
 using Microsoft.ClearScript.V8;
 using System.Text.RegularExpressions;
+using System.IO;
 
 namespace mpost
 {
@@ -17,6 +18,7 @@ namespace mpost
         string raspi_user;
         string raspi_private_key_path;
         string raspi_twitter_token_json_path;
+        string previous_post_file_name;
         V8ScriptEngine v8;
         [DataContract] //データコントラクト属性
         public partial class JsonData
@@ -29,6 +31,7 @@ namespace mpost
         {
             InitializeComponent();
             lblPet.Text = ConfigurationManager.AppSettings["icon_on_form"] ?? "";  // ペットマークを差替
+            previous_post_file_name = ConfigurationManager.AppSettings["previous_post_file_name"] ?? "";
 
             string tt = File.ReadAllText(@"twitter-text-3.1.0.js");
             v8 = new V8ScriptEngine();
@@ -82,6 +85,15 @@ namespace mpost
                     {
                         var res = await PostToSlack(txt);
                         System.Diagnostics.Debug.WriteLine(res);
+                    }
+
+                    if (chkTwitter.Checked || chkSlack.Checked)
+                    {
+                        if (previous_post_file_name.Length > 0)
+                        {
+                            File.WriteAllText(previous_post_file_name, txtMessage.Text);  // 投稿内容をファイル保管
+                        }
+                        txtMessage.Clear();
                     }
                 }
             }
@@ -171,6 +183,19 @@ namespace mpost
                 .Replace(@"\", @"\\")
                 .Replace("\"", "\\\"")
                 .Replace("\r\n", "\\n");
+        }
+
+        private void tsmItemPreviousPost_Click(object sender, EventArgs e)
+        {
+            if (previous_post_file_name.Length > 0 && File.Exists(previous_post_file_name))
+            {
+                txtMessage.Text = File.ReadAllText(previous_post_file_name);
+            }
+        }
+
+        private void tsmItemClear_Click(object sender, EventArgs e)
+        {
+            txtMessage.Clear();
         }
     }
 }

--- a/mpost/mpost.resx
+++ b/mpost/mpost.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="cmsPet.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
🐢のペットマークにコンテクストメニューを追加。
［一つ前の投稿を表示］を用意した。
前回の投稿時に、投稿内容をテキストファイルに保存しておいて
上のメニュークリック時に、その内容を読み込む。
主な用途としては、過去の投稿の編集時に、削除再投稿したい場合。
履歴は複数回持たないことにした。https://github.com/tmatsumor/mpost/issues/10#issuecomment-2212457348 参照。

併せて［クリア］機能も付加した。

トリガーがペットマークの右クリックからの、メニュークリックと
二段階踏んでいるため、確認のダイアログは用意しなかった。

仮にメニューを押し間違えても、損失はない。
（コンテクストメニューは、どちらをクリックしても入力中の文面は失われる）

